### PR TITLE
Improve understandability of sun condition logic

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -586,24 +586,21 @@ def sun(
     before_offset = before_offset or timedelta(0)
     after_offset = after_offset or timedelta(0)
 
-    sunrise_today = get_astral_event_date(hass, SUN_EVENT_SUNRISE, today)
-    sunset_today = get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
+    sunrise = get_astral_event_date(hass, SUN_EVENT_SUNRISE, today)
+    sunset = get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
 
-    sunrise = sunrise_today
-    sunset = sunset_today
-    if today > dt_util.as_local(
-        cast(datetime, sunrise_today)
-    ).date() and SUN_EVENT_SUNRISE in (before, after):
-        tomorrow = dt_util.as_local(utcnow + timedelta(days=1)).date()
-        sunrise_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNRISE, tomorrow)
-        sunrise = sunrise_tomorrow
+    has_sunrise_condition = SUN_EVENT_SUNRISE in (before, after)
+    has_sunset_condition = SUN_EVENT_SUNSET in (before, after)
 
-    if today > dt_util.as_local(
-        cast(datetime, sunset_today)
-    ).date() and SUN_EVENT_SUNSET in (before, after):
-        tomorrow = dt_util.as_local(utcnow + timedelta(days=1)).date()
-        sunset_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNSET, tomorrow)
-        sunset = sunset_tomorrow
+    after_sunrise = today > dt_util.as_local(cast(datetime, sunrise)).date()
+    if after_sunrise and has_sunrise_condition:
+        tomorrow = today + timedelta(days=1)
+        sunrise = get_astral_event_date(hass, SUN_EVENT_SUNRISE, tomorrow)
+
+    after_sunset = today > dt_util.as_local(cast(datetime, sunset)).date()
+    if after_sunset and has_sunset_condition:
+        tomorrow = today + timedelta(days=1)
+        sunset = get_astral_event_date(hass, SUN_EVENT_SUNSET, tomorrow)
 
     # Special case: before sunrise OR after sunset
     # This will handle the very rare case in the polar region when the sun rises/sets
@@ -623,12 +620,12 @@ def sun(
         condition_trace_update_result(wanted_time_after=wanted_time_after)
         return utcnow < wanted_time_before or utcnow > wanted_time_after
 
-    if sunrise is None and SUN_EVENT_SUNRISE in (before, after):
+    if sunrise is None and has_sunrise_condition:
         # There is no sunrise today
         condition_trace_set_result(False, message="no sunrise today")
         return False
 
-    if sunset is None and SUN_EVENT_SUNSET in (before, after):
+    if sunset is None and has_sunset_condition:
         # There is no sunset today
         condition_trace_set_result(False, message="no sunset today")
         return False


### PR DESCRIPTION
Move a few things around, add/remove some temporary variables with the goal of making the (complicated) sunrise/sunset logic in the sun condition a little bit more understandable.